### PR TITLE
Support global options configuration

### DIFF
--- a/bin/incr
+++ b/bin/incr
@@ -10,6 +10,9 @@ include GLI::App
 program_desc('Tasteful utility to increment the version number and create a corresponding git tag.')
 version(Incr::VERSION)
 
+flag [:t,:tagNamePattern], :default_value => 'v%s'
+flag [:d,:versionFileDirectory], :default_value => '.', :desc => 'Directory where to search for version file.'
+
 pre do |global, command, options, args|
   if args.length != 1 || !['major', 'minor', 'patch'].any? {|segment| args.include?(segment)}
     STDERR.puts('Expecting a single argument: major, minor or patch.')
@@ -22,7 +25,7 @@ end
 desc('Increment the version of your NPM package.')
 command :npm do |cmd|
   cmd.action do |global_options, options, args|
-    npm = Incr::Command::Npm.new(args)
+    npm = Incr::Command::Npm.new(args, global_options)
     npm.execute
   end
 end

--- a/bin/incr
+++ b/bin/incr
@@ -10,8 +10,8 @@ include GLI::App
 program_desc('Tasteful utility to increment the version number and create a corresponding git tag.')
 version(Incr::VERSION)
 
-flag [:t,:tagNamePattern], :default_value => 'v%s'
-flag [:d,:versionFileDirectory], :default_value => '.', :desc => 'Directory where to search for version file.'
+flag [:d, :versionFileDirectory], :default_value => '.', :desc => 'Directory where to search for version file.'
+flag [:t, :tagNamePattern], :default_value => 'v%s'
 
 pre do |global, command, options, args|
   if args.length != 1 || !['major', 'minor', 'patch'].any? {|segment| args.include?(segment)}
@@ -34,7 +34,7 @@ end
 desc('Increment the version of your Mix package.')
 command :mix do |cmd|
   cmd.action do |global_options, options, args|
-    mix = Incr::Command::Mix.new(args)
+    mix = Incr::Command::Mix.new(args, global_options)
     mix.execute
   end
 end

--- a/lib/incr/command/mix.rb
+++ b/lib/incr/command/mix.rb
@@ -1,14 +1,14 @@
 module Incr
   module Command
     class Mix
-      MIXFILE_FILENAME = 'mix.exs'.freeze
-
-      def initialize(args)
+      def initialize(args, global_options)
         @segment = args[0]
+        @mixFileFilename = File.join(".", global_options[:versionFileDirectory], 'mix.exs')
+        @tagPattern = global_options[:tagNamePattern]
       end
 
       def execute
-        file_content = parse_content(MIXFILE_FILENAME)
+        file_content = parse_content(@mixFileFilename)
         if file_content == nil
           return
         end
@@ -16,14 +16,16 @@ module Incr
         file_version = file_content.match(/version:\W*\"(\d*.\d*.\d*)",/)[1]
         old_version = SemVersion.new(file_version)
         new_version = Incr::Service::Version.increment_segment(old_version, @segment)
-        Incr::Service::FileHelper.replace_once(MIXFILE_FILENAME, version_pattern(old_version.to_s), version_pattern(new_version.to_s))
+        Incr::Service::FileHelper.replace_once(@mixFileFilename, version_pattern(old_version.to_s), version_pattern(new_version.to_s))
 
-        puts "v#{new_version.to_s}"
+        newTag = @tagPattern % new_version.to_s
+
+        puts newTag
 
         repository = Incr::Service::Repository.new('.')
-        repository.add(MIXFILE_FILENAME)
-        repository.commit(new_version.to_s)
-        repository.tag("v#{new_version.to_s}")
+        repository.add(@mixFileFilename)
+        repository.commit(newTag)
+        repository.tag(newTag)
       end
 
       private

--- a/lib/incr/command/mix.rb
+++ b/lib/incr/command/mix.rb
@@ -3,12 +3,12 @@ module Incr
     class Mix
       def initialize(args, global_options)
         @segment = args[0]
-        @mixFileFilename = File.join(".", global_options[:versionFileDirectory], 'mix.exs')
-        @tagPattern = global_options[:tagNamePattern]
+        @mix_file_filename = File.join('.', global_options[:versionFileDirectory], 'mix.exs')
+        @tag_pattern = global_options[:tagNamePattern]
       end
 
       def execute
-        file_content = parse_content(@mixFileFilename)
+        file_content = parse_content(@mix_file_filename)
         if file_content == nil
           return
         end
@@ -16,16 +16,16 @@ module Incr
         file_version = file_content.match(/version:\W*\"(\d*.\d*.\d*)",/)[1]
         old_version = SemVersion.new(file_version)
         new_version = Incr::Service::Version.increment_segment(old_version, @segment)
-        Incr::Service::FileHelper.replace_once(@mixFileFilename, version_pattern(old_version.to_s), version_pattern(new_version.to_s))
+        Incr::Service::FileHelper.replace_once(@mix_file_filename, version_pattern(old_version.to_s), version_pattern(new_version.to_s))
 
-        newTag = @tagPattern % new_version.to_s
+        new_tag = @tag_pattern % new_version.to_s
 
-        puts newTag
+        puts new_tag
 
         repository = Incr::Service::Repository.new('.')
-        repository.add(@mixFileFilename)
-        repository.commit(newTag)
-        repository.tag(newTag)
+        repository.add(@mix_file_filename)
+        repository.commit(new_tag)
+        repository.tag(new_tag)
       end
 
       private

--- a/lib/incr/command/npm.rb
+++ b/lib/incr/command/npm.rb
@@ -8,14 +8,13 @@ module Incr
       def initialize(args, global_options)
         @segment = args[0]
 
-        @packageJsonFilename = File.join(".", global_options[:versionFileDirectory], 'package.json')
-        @packageJsonLockFilename = File.join(".", global_options[:versionFileDirectory], 'package-lock.json')
-        @tagPattern = global_options[:tagNamePattern]
+        @package_json_filename = File.join('.', global_options[:versionFileDirectory], 'package.json')
+        @package_json_lock_filename = File.join('.', global_options[:versionFileDirectory], 'package-lock.json')
+        @tag_pattern = global_options[:tagNamePattern]
       end
 
       def execute
-
-        package_json = parse_content(@packageJsonFilename)
+        package_json = parse_content(@package_json_filename)
         if package_json == nil
           return
         end
@@ -24,19 +23,18 @@ module Incr
         old_version = SemVersion.new(file_version)
         new_version = Incr::Service::Version.increment_segment(old_version, @segment)
 
-        Incr::Service::FileHelper.replace_once(@packageJsonFilename, version_pattern(old_version.to_s), version_pattern(new_version.to_s))
-        Incr::Service::FileHelper.replace_once(@packageJsonLockFilename, version_pattern(old_version.to_s), version_pattern(new_version.to_s))
+        Incr::Service::FileHelper.replace_once(@package_json_filename, version_pattern(old_version.to_s), version_pattern(new_version.to_s))
+        Incr::Service::FileHelper.replace_once(@package_json_lock_filename, version_pattern(old_version.to_s), version_pattern(new_version.to_s))
 
-        newTag = @tagPattern % new_version.to_s
+        new_tag = @tag_pattern % new_version.to_s
 
-        puts newTag
+        puts new_tag
 
         repository = Incr::Service::Repository.new('.')
-        repository.add(@packageJsonFilename)
-        repository.add(@packageJsonLockFilename)
-        repository.commit(newTag)
-
-        repository.tag(newTag)
+        repository.add(@package_json_filename)
+        repository.add(@package_json_lock_filename)
+        repository.commit(new_tag)
+        repository.tag(new_tag)
       end
 
       private


### PR DESCRIPTION
Added new global options:
```
GLOBAL OPTIONS
    -d, --versionFileDirectory=arg - Directory where to search for version file. (default: .)
    -t, --tagNamePattern=arg       - (default: v%s)
```

Example:
`incr -d ./subprojects/web/ -t 'MyCustomTagPrefix/%s' npm patch`

This will:
- search for `package.json` and `package-lock.json` file inside `subprojects/web/`
- the tage name will be something like `MyCustomTagPrefix/2.3.4`
- the commit message will be `MyCustomTagPrefix/2.3.4`