### PR TITLE
Document new arguments in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ To increment the minor segment of your Mix package version number:
 ~> incr mix minor
 ```
 
+### Arguments
+Here are some arguments that can be used with `incr`:
+- `-d` : Directory where to search for the version files (default: `.`)
+- `-t` : Tag name pattern, where `%s` will be replaced with the new version (default: `v%s`)
+
+Example:
+```shell
+~> incr npm patch -d ./subprojects/web/ -t MyCustomTagPrefix/%s
+```
+
+This will :
+- Search for `package.json` and `package-lock.json` files inside `./subprojects/web/` and update the patch version
+- Create a tag named `MyCustomTagPrefix/2.3.4`
+- Commit the changes under the message `MyCustomTagPrefix/2.3.4`
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/jcouture/incr. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.


### PR DESCRIPTION
Here is some documentation and examples for the new arguments, `-d` and `-t`, that can be passed when calling `incr`.