### PR TITLE
Support --no-commit and --no-tag as switches in global options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,18 @@ To increment the minor segment of your Mix package version number:
 Here are some arguments that can be used with `incr`:
 - `-d` : Directory where to search for the version files (default: `.`)
 - `-t` : Tag name pattern, where `%s` will be replaced with the new version (default: `v%s`)
+- `--[no-]commit` : Commit changes. (default: enabled)
+- `--[no-]tag` : Create a git tag. (default: enabled)
 
 Example:
 ```shell
-~> incr npm patch -d ./subprojects/web/ -t MyCustomTagPrefix/%s
+~> incr --no-tag npm patch -d ./subprojects/web/ -t MyCustomTagPrefix/%s
 ```
 
 This will :
 - Search for `package.json` and `package-lock.json` files inside `./subprojects/web/` and update the patch version
-- Create a tag named `MyCustomTagPrefix/2.3.4`
 - Commit the changes under the message `MyCustomTagPrefix/2.3.4`
+- Not create a tag with the new version
 
 ## Contributing
 

--- a/bin/incr
+++ b/bin/incr
@@ -10,8 +10,11 @@ include GLI::App
 program_desc('Tasteful utility to increment the version number and create a corresponding git tag.')
 version(Incr::VERSION)
 
-flag [:d, :versionFileDirectory], :default_value => '.', :desc => 'Directory where to search for version file.'
-flag [:t, :tagNamePattern], :default_value => 'v%s'
+flag [:d, :versionFileDirectory], :default_value => '.', :desc => 'Directory where to search for version file'
+flag [:t, :tagNamePattern], :default_value => 'v%s', :desc => 'Pattern for the tag name'
+
+switch :commit, :default_value => true, :desc => 'Commit changes'
+switch :tag, :default_value => true, :desc => 'Create a git tag'
 
 pre do |global, command, options, args|
   if args.length != 1 || !['major', 'minor', 'patch'].any? {|segment| args.include?(segment)}

--- a/lib/incr/command/mix.rb
+++ b/lib/incr/command/mix.rb
@@ -5,6 +5,8 @@ module Incr
         @segment = args[0]
         @mix_file_filename = File.join('.', global_options[:versionFileDirectory], 'mix.exs')
         @tag_pattern = global_options[:tagNamePattern]
+        @commit = global_options[:commit]
+        @tag = global_options[:tag]
       end
 
       def execute
@@ -24,8 +26,8 @@ module Incr
 
         repository = Incr::Service::Repository.new('.')
         repository.add(@mix_file_filename)
-        repository.commit(new_tag)
-        repository.tag(new_tag)
+        repository.commit(new_tag) if @commit
+        repository.tag(new_tag) if @tag
       end
 
       private

--- a/lib/incr/command/npm.rb
+++ b/lib/incr/command/npm.rb
@@ -11,6 +11,8 @@ module Incr
         @package_json_filename = File.join('.', global_options[:versionFileDirectory], 'package.json')
         @package_json_lock_filename = File.join('.', global_options[:versionFileDirectory], 'package-lock.json')
         @tag_pattern = global_options[:tagNamePattern]
+        @commit = global_options[:commit]
+        @tag = global_options[:tag]
       end
 
       def execute
@@ -33,8 +35,8 @@ module Incr
         repository = Incr::Service::Repository.new('.')
         repository.add(@package_json_filename)
         repository.add(@package_json_lock_filename)
-        repository.commit(new_tag)
-        repository.tag(new_tag)
+        repository.commit(new_tag) if @commit
+        repository.tag(new_tag) if @tag
       end
 
       private


### PR DESCRIPTION
Added new global options:
```
GLOBAL OPTIONS
    --[no-]commit : Commit changes (default: enabled)
    --[no-]tag : Create a git tag (default: enabled)
```

Example:
`incr --no-commit --no-tag npm patch`

This will:
- increment the version number without commiting changes nor creating a tag

Note:
Using `--commit` or `--tag` has no real effect, since `options[:commit]` and `options[:tag]` are true by default