### PR TITLE
Add support for NPM lockfile v2

### DIFF
--- a/lib/incr/command/mix.rb
+++ b/lib/incr/command/mix.rb
@@ -52,7 +52,7 @@ module Incr
           old_version_pattern = format(pattern, old_version.to_s)
           new_version_pattern = format(pattern, new_version.to_s)
 
-          Incr::Service::FileHelper.replace_once(@mix_file_filename, old_version_pattern, new_version_pattern)
+          Incr::Service::FileHelper.replace_string_once(@mix_file_filename, old_version_pattern, new_version_pattern)
         end
       end
     end

--- a/lib/incr/service/file_helper.rb
+++ b/lib/incr/service/file_helper.rb
@@ -1,9 +1,13 @@
 module Incr
   module Service
     class FileHelper
-      def self.replace_once(filename, old_text, new_text)
+      def self.replace_string_once(filename, old_text, new_text)
+        replace_regexp_once(/#{Regexp.escape(old_text)}/, new_text)
+      end
+
+      def self.replace_regexp_once(filename, pattern, replacement_text)
         old_content = File.read(filename)
-        new_content = old_content.sub(/#{Regexp.escape(old_text)}/, new_text)
+        new_content = old_content.sub(pattern, replacement_text)
         File.open(filename, 'w') { |file| file << new_content }
       end
     end


### PR DESCRIPTION
## Context

`npm>6` generates a lockfile `v2` which is not totally supported by `incr`.

The lockfile `v2` adds a new `"packages"` attribute that describes all the packages used by the project, identified by their relative path. The project is part of these packages and is identified by `""`.
```json
{
  "name": "incr-example",
  "version": "1.0.0",
  "lockfileVersion": 2,
  "packages": {
    "": {
      "name": "incr-example",
      "version": "1.0.0"
    },
    "node_modules/some-dep": {
      "version": "1.0.0"
    }
  }
}
```

## Motivation

`incr` replaces the first `"version"` attribute in both `package.json` and `package-lock.json`, leaving `packages[""].version` untouched. After the CI pipeline bumps the version using `incr`, the `package-lock.json` is in an invalid state, meaning the next time a developer runs `npm i`, the `package-lock.json` will need to be commited again.

## Considered solutions

1. **Use `replace_all` instead of `replace_once`**
  ❌ This solution might replace a dependency version. In the example above, it would replace both `incr-example` and `some-dep` versions.

2. **Parse the `package-lock.json` file, edit the json object and replace the file with updated json object**
  ❌ The lockfile format might be lost and the next developer that runs `npm i` shall commit the file again.

3. **Use `npm i --package-lock-only` to update the `package-lock.json` file**
  ❌ The `--package-lock-only` works since `npm@7`, meaning that lower versions would reinstall all packages only to upgrade a version number.

## Final solution

### Regular expressions 🌈
Using `\K`, we can reset the regexp match cursor, meaning that we can
* use a regular expression that finds the object to update, 
* reset the regexp match cursor
* use a regular expression that match a semver version
* replace the match with the new version.

### Patterns explained
1. `/\A{[^{}]*"version": "\K[\w\.\-]*/`
    * `\A{` matches the root object `{`
    * `[^{}]*` matches anything but curly braces (should not leave the root object)
    * `"version": "` matches the version attribute
    * `\K` resets the match cursor
    * `[\w\.\-]*` matches the semver version to replace

2. `/\A{[^{}]*"version": "\K[\w\.\-]*/`
    * `"": {` matches the project's package with `"": {`
    * `[^{}]*` matches anything but curly braces (should not leave the project's package object)
    * `"version": "` matches the version attribute
    * `\K` resets the match cursor
    * `\w\.\-]*` matches the semver version to replace