### PR TITLE
Create *annotated* git tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The process is detailed as follow:
 * Increment the specified segment. If you increment the minor segment, the patch segment is set to 0 and the same goes for the major segment, the minor and patch segments are set to 0.
 * Write the newly incremented version number in the relevant file(s).
 * Create a new `git commit` with the relevant file with the version number as the default message (e.g.: 0.2.1).
-* Create a new `git tag` pointing to the new `git commit` with the version number prefixed by a 'v' as the name (e.g.: v0.2.1).
+* Create a new annotated `git tag` pointing to the new `git commit` with the version number prefixed by a 'v' as the name (e.g.: v0.2.1).
 * 💥
 
 ## Installation

--- a/lib/incr/service/repository.rb
+++ b/lib/incr/service/repository.rb
@@ -16,7 +16,7 @@ module Incr
       end
 
       def tag(name)
-        @git.add_tag(name)
+        @git.add_tag(name, annotate: true, message: name)
       end
     end
   end


### PR DESCRIPTION
Git supports [two types of tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging#_creating_tags):

- Lightweight
- Annotated

> A lightweight tag is very much like a branch that doesn’t change — it’s just a pointer to a specific commit.
>
> Annotated tags, however, are stored as full objects in the Git database. They’re checksummed; contain the tagger name, email, and date; have a tagging message; and can be signed and verified with GNU Privacy Guard (GPG). It’s generally recommended that you create annotated tags so you can have all this information; but if you want a temporary tag or for some reason don’t want to keep the other information, lightweight tags are available too.

I believe Incr should be creating _annoated_ tags, not lightweight ones 🙂
