### PR TITLE
Add support for SemVer extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <img src="https://user-images.githubusercontent.com/5007/160249855-dc0eb32f-f77d-4c5a-a995-93ac46408a68.png" alt="incr" />
   </a>
   <br />
-  incr is a tool to help you easily increment the version number of your NPM or Mix packages.
+  incr is designed to streamline the process of incrementing the version number of your NPM or Mix packages.
   <br /><br />
   <a href="https://rubygems.org/gems/incr"><img src="http://img.shields.io/gem/v/incr.svg" /></a>
 </p>
@@ -12,13 +12,13 @@
 
 The process is detailed as follow:
 
-*  Find the relevant file(s) (e.g.: `package.json` and `package-lock.json` or `mix.exs`).
-* Determine the existing version number.
-* Increment the specified segment. If you increment the minor segment, the patch segment is set to 0 and the same goes for the major segment, the minor and patch segments are set to 0.
-* Write the newly incremented version number in the relevant file(s).
-* Create a new `git commit` with the relevant file with the version number as the default message (e.g.: 0.2.1).
-* Create a new annotated `git tag` pointing to the new `git commit` with the version number prefixed by a 'v' as the name (e.g.: v0.2.1).
-* 💥
+- Find the relevant file(s) (e.g.: `package.json` and `package-lock.json` or `mix.exs`).
+- Determine the existing version number.
+- Increment the specified segment. If you increment the minor segment, the patch segment is set to 0 and the same goes for the major segment, the minor and patch segments are set to 0.
+- Write the newly incremented version number in the relevant file(s).
+- Create a new `git commit` with the relevant file with the version number as the default message (e.g.: 0.2.1).
+- Create a new annotated `git tag` pointing to the new `git commit` with the version number prefixed by a 'v' as the name (e.g.: v0.2.1).
+- 💥
 
 ## Installation
 
@@ -42,12 +42,19 @@ To increment the minor segment of your Mix package version number:
 ~> incr mix minor
 ```
 
+To increment the prerelease segment of your NPM package version number, while specifying an identifier (`rc`):
+
+```shell
+~> incr -i rc mix prerelease
+```
+
 ### Arguments
 
 Here are some arguments that can be used with `incr`:
 
 - `-d` : Directory where to search for the version files (default: `.`)
 - `-t` : Tag name pattern, where `%s` will be replaced with the new version (default: `v%s`)
+- `-i` : Identifier for the prerelease segment (default: `alpha`)
 - `--[no-]commit` : Commit changes. (default: enabled)
 - `--[no-]tag` : Create a git tag. (default: enabled)
 
@@ -57,7 +64,7 @@ Example:
 ~> incr --no-tag -d ./subprojects/web/ -t my-custom-tag-prefix/%s npm patch
 ```
 
-This will :
+This will:
 
 - Search for `package.json` and `package-lock.json` files inside `./subprojects/web/` and update the patch version
 - Commit the changes under the message `my-custom-tag-prefix/2.3.4`
@@ -69,4 +76,4 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/jcoutu
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+This lovely gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/bin/incr
+++ b/bin/incr
@@ -12,13 +12,14 @@ version(Incr::VERSION)
 
 flag([:d, :version_file_dir], default_value: '.', desc: 'Directory where to search for version file')
 flag([:t, :tag_name_pattern], default_value: 'v%s', desc: 'Pattern for the tag name')
+flag([:i, :identifier], default_value: nil, desc: 'Identifier for the prerelease segment')
 
 switch(:commit, default_value: true, desc: 'Commit changes')
 switch(:tag, default_value: true, desc: 'Create a git tag')
 
 pre do |global, command, options, args|
-  if args.length != 1 || !['major', 'minor', 'patch'].any? {|segment| args.include?(segment)}
-    warn('expecting a single argument: major, minor or patch.')
+  if args.length != 1 || !['major', 'minor', 'patch', 'prerelease'].any? {|segment| args.include?(segment)}
+    warn('expecting a single argument: major, minor, patch or prerelease.')
     return false
   end
   true

--- a/bin/incr
+++ b/bin/incr
@@ -12,7 +12,7 @@ version(Incr::VERSION)
 
 flag([:d, :version_file_dir], default_value: '.', desc: 'Directory where to search for version file')
 flag([:t, :tag_name_pattern], default_value: 'v%s', desc: 'Pattern for the tag name')
-flag([:i, :identifier], default_value: nil, desc: 'Identifier for the prerelease segment')
+flag([:i, :identifier], default_value: 'alpha', desc: 'Identifier for the prerelease segment')
 
 switch(:commit, default_value: true, desc: 'Commit changes')
 switch(:tag, default_value: true, desc: 'Create a git tag')

--- a/lib/incr/command/mix.rb
+++ b/lib/incr/command/mix.rb
@@ -14,6 +14,7 @@ module Incr
         @commit = global_options[:commit]
         @tag = global_options[:tag]
         @noop = global_options[:noop]
+        @identifier = global_options[:identifier]
       end
 
       def execute
@@ -29,7 +30,7 @@ module Incr
 
         file_version = file_content.match(VERSION_REGEX)[1]
         old_version = SemVersion.new(file_version)
-        new_version = Incr::Service::Version.increment_segment(old_version, @segment)
+        new_version = Incr::Service::Version.increment_segment(old_version, @segment, @identifier)
         replace_file_version(old_version, new_version)
 
         new_tag = @tag_pattern % new_version.to_s

--- a/lib/incr/command/npm.rb
+++ b/lib/incr/command/npm.rb
@@ -22,6 +22,7 @@ module Incr
         @commit = global_options[:commit]
         @tag = global_options[:tag]
         @noop = global_options[:noop]
+        @identifier = global_options[:identifier]
       end
 
       def execute
@@ -42,7 +43,7 @@ module Incr
 
         file_version = package_json['version']
         old_version = SemVersion.new(file_version)
-        new_version = Incr::Service::Version.increment_segment(old_version, @segment)
+        new_version = Incr::Service::Version.increment_segment(old_version, @segment, @identifier)
 
         replace_file_version(@package_json_filename, new_version.to_s)
         replace_file_version(@package_json_lock_filename, new_version.to_s)

--- a/spec/incr/service/version_spec.rb
+++ b/spec/incr/service/version_spec.rb
@@ -40,5 +40,53 @@ describe Incr::Service::Version do
         }.to raise_error(NoMethodError)
       end
     end
+
+    context 'without a prerelease version' do
+      let(:version) { SemVersion.new('1.0.0') }
+
+      it 'increments the prerelease segment' do
+        expected = '1.0.1-alpha.1'
+        result = Incr::Service::Version.increment_segment(version, 'prerelease', 'alpha')
+        expect(result.to_s).to eql(expected)
+      end
+    end
+    
+    context 'with a prerelease version' do
+      let(:version) { SemVersion.new('1.0.0-alpha.1') }
+
+      it 'increments the prerelease segment' do
+        expected = '1.0.0-alpha.2'
+        result = Incr::Service::Version.increment_segment(version, 'prerelease')
+        expect(result.to_s).to eql(expected)
+      end
+
+      it 'increments the prerelease segment with a custom identifier' do
+        expected = '1.0.0-rc.1'
+        result = Incr::Service::Version.increment_segment(version, 'prerelease', 'rc')
+        expect(result.to_s).to eql(expected)
+      end
+
+      it 'increments the prerelease segment with a custom identifier and resets the prerelease segment' do
+        expected = '1.0.0-rc.1'
+        result = Incr::Service::Version.increment_segment(version, 'prerelease', 'rc')
+        expect(result.to_s).to eql(expected)
+      end
+
+      it 'increments the prerelease segment with a custom identifier and resets the prerelease segment' do
+        expected = '1.0.0-rc.1'
+        result = Incr::Service::Version.increment_segment(version, 'prerelease', 'rc')
+        expect(result.to_s).to eql(expected)
+      end
+
+      it 'increments the minor segment' do
+        expected = '1.1.0'
+        result = Incr::Service::Version.increment_segment(version, 'minor')
+        expect(result.to_s).to eql(expected)
+      end
+
+      it 'handles empty custom identifier' do
+        expect { Incr::Service::Version.increment_segment(version, 'prerelease', '') }.to raise_error(ArgumentError)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds support for the pre-release and build metadata labels, as described by the [SemVer](https://semver.org) specification.